### PR TITLE
Add layered security contexts.

### DIFF
--- a/draft-ietf-tls-external-psk-importer.md
+++ b/draft-ietf-tls-external-psk-importer.md
@@ -156,7 +156,7 @@ The `Context` in this case includes the `ImportedIdentity` plus any necessary ad
 Context.client_id is an optional field that is required to be unique for each actor that knows the EPSK.
 See section {{client-id-description}} for more details.
 
-Context.prior_contexts is a list of prior security contexts, consisting of channel bindings and 
+Context.prior_contexts is a list of prior security contexts, consisting of channel bindings and
 any associated keys. See section {{prior-contexts-description}} for more details.
 
 [[TODO: The length of ipskx MUST match that of the corresponding and supported ciphersuites.]]
@@ -180,18 +180,18 @@ QUIC transport settings, etc., must be provisioned alongside these EPSKs.
 
 ## Client ID {#client-id-description}
 
-The `client_id` is an optional field. If used, the `client_id` MUST be unique 
+The `client_id` is an optional field. If used, the `client_id` MUST be unique
 for each actor that knows the EPSK. This is to prevent Selfie-style reflections {{Selfie}}.
 If two actors have the same `client_id` this defense may not be effective.
-This field is only necessary in scenarios where more than two actors 
-use the same PSK, including the case where a single agent will complete 
+This field is only necessary in scenarios where more than two actors
+use the same PSK, including the case where a single agent will complete
 PSK handshakes as both the client and the server using the same key.
 See {{selfie-style-reflections}} for more details about this attack.
 
 For example, a unique `client_id` for agents in peer-to-peer IoT device deployments could be a MAC address.
 Similarly, a unique `client_id` for agents in mesh VM deployments could be a namespace.
 The decision to use this field and what it should contain MUST be agreed OOB.
-Note that, critically, the TLS protocol never sends `client_id` on the wire, 
+Note that, critically, the TLS protocol never sends `client_id` on the wire,
 as this would identify the client even to passive adverseries.
 
 ## Prior Contexts {#prior-contexts-description}
@@ -218,14 +218,14 @@ implementers using this field:
 ### Example
 
 As an example, consider chaining together two TLS sessions using OOB PSK importers rather than resumption.
-One could then include the prior context `<tls_channel_binding, master_secret>` in the second connection, 
-where `tls_channel_binding` is computed by calling the TLS exporter interface of the first connection with 
+One could then include the prior context `<tls_channel_binding, master_secret>` in the second connection,
+where `tls_channel_binding` is computed by calling the TLS exporter interface of the first connection with
 a label that uniquely defines this particular setup.
 
-Including this channel binding in the prior contexts binds the security context of the first channel 
-to the security context of the second channel. This allows reasoning about the security contexts of 
-both sessions at once. For example this pattern might be useful if the security of the second channel's 
-PSK is in doubt, as an attacker would need to compromise both the first channel and the second channel 
+Including this channel binding in the prior contexts binds the security context of the first channel
+to the security context of the second channel. This allows reasoning about the security contexts of
+both sessions at once. For example this pattern might be useful if the security of the second channel's
+PSK is in doubt, as an attacker would need to compromise both the first channel and the second channel
 to mount a successful attack.
 
 [[NOTE: This is simply an illustrative sketch and has not seen any security analysis.]]
@@ -312,14 +312,14 @@ In this case, there are two clients and two servers that know the PSK, since eac
 
 The agents are thus both vulnerable to reflection attacks where the attacker reflects all handshake messages back on the agent.
 This forces the agent to act as both client and server in a single connection.
-Because both clients have identical configurations, an agent acting as a server cannot 
+Because both clients have identical configurations, an agent acting as a server cannot
 distinguish between its peer acting as a client, and itself acting as a client.
-Adding a role-based label is ineffective, as both the agent and its peer will add 
+Adding a role-based label is ineffective, as both the agent and its peer will add
 the `client` label when acting as a client, leaving them indistinguishable.
 
 The `client_id` is both constant between sessions, and different for each agent.
-The `client_id` is included in the computation of `ipskx`, and therefore is included in 
-the computation of the PSK binder. A server that received a reflected `ClientHello` would 
+The `client_id` is included in the computation of `ipskx`, and therefore is included in
+the computation of the PSK binder. A server that received a reflected `ClientHello` would
 try and compute the binder using the `client_id` of its peer, and thus would be unable to verify the binder.
-The server would therefore reject the connection. This specifically breaks the symmetry of 
+The server would therefore reject the connection. This specifically breaks the symmetry of
 the configurations such that agents are distinguishable.

--- a/draft-ietf-tls-external-psk-importer.md
+++ b/draft-ietf-tls-external-psk-importer.md
@@ -186,6 +186,9 @@ A pair of agents that both act as both client *and* server, and use the same PSK
 In this case, there are two clients and two servers that know the PSK, since each endpoint acts as both client and server.
 The agents are thus both vulnerable to reflection attacks where the attacker forces the agent to act as both client and server in a single connection.
 This is because neither agent can distinguish between itself and its peer.
+Recall both servers have the exact same configuration.
+Therefore even though the session specific parameters change for each session, the client cannot distinguish between a response reflected back on it by the attacker and an honest response from its peer.
+For each parameter, both servers either return the value for every session, or they return a different value for every session.
 By hashing a distinguishing `client_id` value into the PSK binder, a server that received a reflected `ClientHello` would be unable to verify the binder, and would reject the connection.
 
 For example, distinguishing strings for agents in peer-to-peer IoT device deployments could be a MAC address.

--- a/draft-ietf-tls-external-psk-importer.md
+++ b/draft-ietf-tls-external-psk-importer.md
@@ -179,33 +179,17 @@ otherwise be required for early data with normal (ticket-based PSK) resumption. 
 QUIC transport settings, etc., must be provisioned alongside these EPSKs.
 
 ##Client ID {#client-id-description}
-The `client_id` is an optional field that is required to be unique for each actor that knows the EPSK.
-This is to prevent Selfie-style reflections.
-If two actors use the same `client_id` this defence may not be effective. 
-This is only necessary in scenarios where more than two actors use the same key, including the case where a single agent will complete PSK handshakes as both the client and the server using the same key.
+The `client_id` is an optional field.
+If used, the `client_id` MUST be unique for each actor that knows the EPSK.
+This is to prevent Selfie-style reflections {{Selfie}}.
+If two actors have the same `client_id` this defense may not be effective.
+This field is only necessary in scenarios where more than two actors use the same PSK, including the case where a single agent will complete PSK handshakes as both the client and the server using the same key.
+For a more in-depth description see {{selfie-style-reflections}}.
 
-The Selfie attack {{Selfie}} abuses an underlying assumption of TLS, that only one client and one server know a PSK.
-A pair of agents that both act as both client *and* server, and use the same PSK in both roles violate this assumption.
-In this case, there are two clients and two servers that know the PSK, since each endpoint acts as both client and server.
-
-Because both clients have identical configurations, an agent acting as a server can't distinguish between its peer acting as a client, and itself acting as a client.
-The agents are thus both vulnerable to reflection attacks where the attacker forces the agent to act as both client and server in a single connection.
-Adding a role-based label is ineffective, as both the agent and its peer will add the `client` label when acting as a client, leaving them indistinguishable.
-
-Recall both clients have identical configurations.
-Therefore even though the session specific parameters change for each session, the server cannot distinguish between a `ClientHello` reflected back on it by the attacker and a `ClientHello` from its peer.
-
-Broadly speaking, there are two types of parameters in the TLS handshake, those which are constant between sessions, and those which change with every session.
-Parameters that are constant between sessions can be used to 'fingerprint' peers, however, if two agents have the same configuration, they will have the same 'fingerprint'.
-Parameters that change with each session cannot be used to distinguish between two peers, because the values are always unrelated.
-
-By hashing a distinguishing `client_id` value into the PSK binder, a server that received a reflected `ClientHello` would be unable to verify the binder, and would reject the connection.
-This specifically breaks the symmetry of the configurations such that agents are distinguishable.
-
-For example, distinguishing strings for agents in peer-to-peer IoT device deployments could be a MAC address.
-Similarly, distinguishing strings for agents in mesh VM deployments could be namespaces.
+For example, a unique `client_id` for agents in peer-to-peer IoT device deployments could be a MAC address.
+Similarly, a unique `client_id` for agents in mesh VM deployments could be a namespace.
 The decision to use this field and what it should contain MUST be agreed OOB.
-Note that, critically, the TLS protocol never sends this value on the wire, as this would identify the client even to passive adverseries.
+Note that, critically, the TLS protocol never sends `client_id` on the wire, as this would identify the client even to passive adverseries.
 
 ##Prior Contexts {#prior-contexts-description}
 In the standard case this list will be empty because the TLS connection will not be wrapped in a prior security context.
@@ -213,12 +197,14 @@ However, if the OOB PSK was established through a protocol, or series of protoco
 This makes it easier to reason formally about the exact properties are provided by the combined series of protocols.
 
 For the purposes of retaining keys the sequence of protocols should be regarded as a series of nested sessions.
-It is not generally considered best practice to maintain keys beyond the lifetime of a session, however, to establish a combined security context, in particular to provide compound authentication {{CCB}}, it is required that the secrets established in all previous sessions be included in all later ones.
+It is not generally considered best practice to maintain keys beyond the lifetime of a session.
+In this case, because we want to establish a combined security context it is required that the secrets established in all previous sessions be included in all later ones.
+In particular this is required to provide compound authentication {{CCB}}.
 Simply including channel bindings is insufficient, because, per {{!RFC5056}}, revealing a channel binding to an attacker must not weaken the scheme.
 To satisfy the requirements:
 
   1. that keys not be retained longer than necessary, and
-  2. that channel bindings must not depend on secrecy for their security:
+  2. that channel bindings must not depend on secrecy for their security
 
 implementers using this field:
 
@@ -309,3 +295,22 @@ The authors thank Eric Rescorla and Martin Thomson for discussions that led to t
 as well as Christian Huitema for input regarding privacy considerations of external PSKs. John Mattsson
 provided input regarding PSK importer deployment considerations.
 
+#Selfie-style Reflections {#selfie-style-reflections}
+The Selfie attack abuses an underlying assumption of TLS, i.e. that only one client and one server know a given PSK.
+A pair of agents that both act as both client and server, and use the same PSK in both roles violate this assumption.
+In this case, there are two clients and two servers that know the PSK, since each endpoint acts as both client and server.
+
+The agents are thus both vulnerable to reflection attacks where the attacker reflects all handshake messages back on the agent.
+This forces the agent to act as both client and server in a single connection.
+Because both clients have identical configurations, an agent acting as a server can't distinguish between its peer acting as a client, and itself acting as a client.
+Adding a role-based label is ineffective, as both the agent and its peer will add the `client` label when acting as a client, leaving them indistinguishable.
+
+Broadly speaking, there are two types of parameters in the TLS handshake, those which are constant between sessions, and those which change with every session.
+Only parameters that are constant between sessions can be used to 'fingerprint' peers, however, if two agents have the same configuration, they will have the same 'fingerprint'.
+Whilst a role-based label is constant between sessions, it doesn't break the symmetry of the configurations.
+
+The `client_id` is both constant between sessions, and different for each agent.
+The `client_id` is included in the computation of `ipskx`, and therefore is included in the computation of the PSK binder.
+A server that received a reflected `ClientHello` would try and compute the binder using the `client_id` of its peer, and thus would be unable to verify the binder.
+The server would therefore reject the connection.
+This specifically breaks the symmetry of the configurations such that agents are distinguishable.


### PR DESCRIPTION
The new design allows users to include security contexts into the PSK binders, ensuring that both parties agree on the source of the OOB PSK. 

The security contexts are a list of pairs `<channel_binding, secret>`, which in the vanilla case will be empty. However if the OOB PSK is established using a different protocol that provides different security guarantees, then this structure allows you to reason about the effect of those properties on the properties of the TLS channel. 