### PR TITLE
Compact and future-proof the ImportedIdentity structure

### DIFF
--- a/draft-ietf-tls-external-psk-importer.md
+++ b/draft-ietf-tls-external-psk-importer.md
@@ -155,7 +155,7 @@ A unique and imported PSK (IPSK) with base key 'ipskx' bound to this identity is
 
 The hash function used for HKDF {{!RFC5869}} is that which is associated with the external PSK. It is not
 bound to ImportedIdentity.kdf. If no hash function is specified, SHA-256 MUST be used.
-Differentiating epsk by ImportedIdentity.kdf ensures that each imported PSK is only used with at most one
+Differentiating EPSK by ImportedIdentity.kdf ensures that each imported PSK is only used with at most one
 hash function, since each KDF is associated with one hash function, thereby satisfying the
 requirements in {{!RFC8446}}.
 


### PR DESCRIPTION
Replace the variable length info string with a 2-octet protocol version
codepoint. Replace HashAlgorithm with a KDF identifier and corresponding
registry. Add HKDF-SHA256 and HKDF-SHA512 to the KDF identifier table.

See #15 for discussion around this change.