### PR TITLE
Make ImportedIdentities target protocol versions and KDFs

### DIFF
--- a/draft-ietf-tls-external-psk-importer.md
+++ b/draft-ietf-tls-external-psk-importer.md
@@ -13,16 +13,16 @@ stand_alone: yes
 pi: [toc, sortrefs, symrefs]
 
 author:
- -
-       ins: D. Benjamin
-       name: David Benjamin
-       organization: Google, LLC.
-       email: davidben@google.com
- -
-       ins: C. A. Wood
-       name: Christopher A. Wood
-       organization: Apple, Inc.
-       email: cawood@apple.com
+  -
+    ins: D. Benjamin
+    name: David Benjamin
+    organization: Google, LLC.
+    email: davidben@google.com
+  -
+    ins: C. A. Wood
+    name: Christopher A. Wood
+    organization: Apple, Inc.
+    email: cawood@apple.com
 
 
 normative:
@@ -62,13 +62,14 @@ could possibly be re-used in two different contexts with the same hash functions
 derivation. Moreover, it requires external PSKs to be provisioned for specific hash
 functions.
 
-To mitigate these problems, external PSKs can be bound to a specific hash function when used
-in TLS 1.3, even if they are associated with a different KDF (and hash function) when provisioned. This document
-specifies an interface by which external PSKs may be imported for use in a TLS 1.3 connection
+To mitigate these problems, external PSKs can be bound to a specific KDF and hash function
+when used in TLS 1.3, even if they are associated with a different hash function when provisioned.
+This document specifies an interface by which external PSKs may be imported for use in a TLS 1.3 connection
 to achieve this goal. In particular, it describes how KDF-bound PSKs can be differentiated by
-different hash algorithms to produce a set of candidate PSKs, each of which are bound to a specific
-hash function. This expands what would normally have been a single PSK identity into a set of
-PSK identities. However, it requires no change to the TLS 1.3 key schedule.
+the target (D)TLS protocol version and KDF for which the PSK will be used. This produces a set
+of candidate PSKs, each of which are bound to a specific target protocol and KDF. This expands what
+would normally have been a single PSK identity into a set of PSK identities. However, importantly,
+it requires no change to the TLS 1.3 key schedule.
 
 # Conventions and Definitions
 
@@ -79,77 +80,89 @@ when, and only when, they appear in all capitals, as shown here.
 
 # Overview
 
-Intuitively, key importers mirror the concept of key exporters in TLS in that they
-diversify a key based on some contextual information before use in a connection. In contrast to
-key exporters, wherein differentiation is done via an explicit label and context string,
-the key importer defined herein uses a label and set of hash algorithms to
-differentiate an external PSK into one or more PSKs for use.
+Key importers mirror the concept of key exporters in TLS in that they diversify a key
+based on some contextual information before use in a connection. In contrast to key exporters,
+wherein differentiation is done via an explicit label and context string, the key importer
+defined herein uses an optional context string along with a target protocol and KDF
+identifier to differentiate an external PSK into one or more PSKs for use.
 
 Imported keys do not require negotiation for use, as a client and server will not agree upon
 identities if not imported correctly. Thus, importers induce no protocol changes with
-the exception of expanding the set of PSK identities sent on the wire. Endpoints may incrementally
-deploy PSK importer support by offering non-imported keys for TLS versions prior to TLS 1.3.
-(Negotiation and use of imported PSKs requires both endpoints support the importer API described herein.)
+the exception of expanding the set of PSK identities sent on the wire. Endpoints may
+incrementally deploy PSK importer support by offering non-imported keys for TLS versions
+prior to TLS 1.3. (Negotiation and use of imported PSKs requires both endpoints support
+the importer API described herein.)
+
+Clients which import external keys TLS MUST NOT use these keys for any other purpose.
+Moreover, each external PSK MUST be associated with at most one hash function.
 
 ## Terminology {#terminology}
 
-- External PSK (EPSK): A PSK established or provisioned out-of-band, i.e., not from a TLS connection, which is
-a tuple of (Base Key, External Identity, KDF). The associated KDF (and hash function) may be undefined.
+- External PSK (EPSK): A PSK established or provisioned out-of-band, i.e., not from a TLS
+connection, which is a tuple of (Base Key, External Identity, Hash). The associated hash
+function may be undefined.
 - Base Key: The secret value of an EPSK.
 - External Identity: The identity of an EPSK.
 - Imported Identity: The identity of a PSK as sent on the wire.
+- Target protocol: The protocol for which a PSK is imported for use.
+- Target KDF: The KDF for which a PSK is imported for use.
 
 # Key Import
 
-A key importer takes as input an EPSK with external identity 'external_identity' and base key 'epsk',
-as defined in {{terminology}}, along with an optional label, and transforms
-it into a set of PSKs and imported identities for use in a connection based on supported HashAlgorithms.
-In particular, for each supported HashAlgorithm 'hash', the importer constructs an ImportedIdentity
-structure as follows:
+A key importer takes as input an EPSK with external identity `external_identity` and base key `epsk`,
+as defined in {{terminology}}, along with an optional context, and transforms it into a set of PSKs
+and imported identities for use in a connection based on supported (target) protocols and KDFs. In particular,
+for each supported target protocol `target_protocol` and KDF `target_kdf`, the importer constructs
+an ImportedIdentity structure as follows:
 
 ~~~
-   struct {
-       opaque external_identity<1...2^16-1>;
-       opaque context<0..2^16-1>;
-       uint16 protocol;
-       HashAlgorithm hash;
-   } ImportedIdentity;
+uint8 KDFID[2];
+
+struct {
+   opaque external_identity<1...2^16-1>;
+   opaque context<0..2^16-1>;
+   uint16 target_protocol;
+   KDFID target_kdf;
+} ImportedIdentity;
 ~~~
 
-[[TODO: An alternative design might combine label and hash into the same field so that future
-protocols which don't have a notion of HashAlgorithm don't need this field.]]
+The list of KDFID values is maintained by IANA as described in {{IANA}}.
 
-ImportedIdentity.context MUST include the context used to derive the EPSK, if any exists.  If the EPSK is a key derived
-from some other protocol or sequence of protocols, ImportedIdentity.context MUST include a channel binding for the deriving protocols
-{{!RFC5056}}.  If any secrets are agreed in earlier protocols they SHOULD be included in ImportedIdentity.context [CCB].
+ImportedIdentity.context MUST include the context used to derive the EPSK, if any exists.
+If the EPSK is a key derived from some other protocol or sequence of protocols,
+ImportedIdentity.context MUST include a channel binding for the deriving protocols
+{{!RFC5056}}.  If any secrets are agreed in earlier protocols they SHOULD be included
+in ImportedIdentity.context {{CCB}}.
 
-ImportedIdentity.protocol MUST be the (D)TLS protocol version for which the PSK is being imported.
-For example, TLS 1.3 and QUICv1 {{!I-D.ietf-quic-transport}} MUST use 0x0304, whereas TLS 1.2
-uses 0x0303 and DTLS 1.2 uses 0xFEFD. Note that this means future versions of TLS will increase
-the number of PSKs derived from an external PSK.
+ImportedIdentity.target_protocol MUST be the (D)TLS protocol version for which the
+PSK is being imported. For example, TLS 1.3 {{!RFC8446}} and QUICv1 {{!I-D.ietf-quic-transport}}
+MUST use 0x0304, whereas TLS 1.2 uses 0x0303 and DTLS 1.2 uses 0xFEFD. Note that this means
+future versions of TLS will increase the number of PSKs derived from an external PSK.
 
 An imported PSK (IPSK) with base key 'ipskx' bound to this identity is then computed as follows:
 
 ~~~
    epskx = HKDF-Extract(0, epsk)
    ipskx = HKDF-Expand-Label(epskx, "derived psk",
-                             Hash(ImportedIdentity), Hash.length)
+                             Hash(ImportedIdentity), L)
 ~~~
 
-[[TODO: The length of ipskx MUST match that of the corresponding and supported ciphersuites.]]
+L is the length of the hash function associated with ImportedIdentity.target_kdf, as this
+is required for the imported PSK to be of suitable length with compatible ciphersuites.
+The hash function used for HKDF {{!RFC5869}} is that which is associated with the external PSK.
+It is not the hash function associated with ImportedIdentity.target_kdf. If no hash function
+is specified, SHA-256 MUST be used. Differentiating epsk by ImportedIdentity.target_kdf ensures
+that an imported PSK is only used as input keying material to at most one KDF, thus satisfying
+the requirements in {{!RFC8446}}.
 
-The hash function used for HKDF {{!RFC5869}} is that which is associated with the external PSK. It is not
-bound to ImportedIdentity.hash. If no hash function is specified, SHA-256 MUST be used.
-Differentiating epsk by ImportedIdentity.hash ensures that each imported PSK is only used with at most one
-hash function, thus satisfying the requirements in {{!RFC8446}}. Endpoints MUST import and derive an ipsk
-for each hash function used by each ciphersuite they support. For example, importing a key for
-TLS_AES_128_GCM_SHA256 and TLS_AES_256_GCM_SHA384 would yield two PSKs, one for SHA256 and another
-for SHA384. In contrast, if TLS_AES_128_GCM_SHA256 and TLS_CHACHA20_POLY1305_SHA256 are supported,
-only one derived key is necessary.
+Endpoints MUST import an ipskx for each target KDF they support. For example, importing a key for
+TLS_AES_128_GCM_SHA256 and TLS_AES_256_GCM_SHA384 would yield two PSKs, one for HKDF-SHA256 and
+another for HKDF-SHA384. In contrast, if TLS_AES_128_GCM_SHA256 and TLS_CHACHA20_POLY1305_SHA256
+are supported, only one derived key is necessary.
 
 The resulting IPSK base key 'ipskx' is then used as the binder key in TLS 1.3 with identity
-ImportedIdentity. With knowledge of the supported hash functions, one may import PSKs before
-the start of a connection.
+ImportedIdentity. With knowledge of the supported KDFs, one may import PSKs before the start
+of a connection.
 
 EPSKs may be imported for early data use if they are bound to protocol settings and configurations that would
 otherwise be required for early data with normal (ticket-based PSK) resumption. Minimally, that means ALPN,
@@ -169,9 +182,9 @@ For clarity, the following table specifies PSK importer labels for varying insta
 
 # Deprecating Hash Functions
 
-If a client or server wish to deprecate a hash function and no longer use it for TLS 1.3, they may remove this
-hash function from the set of hashes used during while importing keys. This does not affect the KDF operation
-used to derive concrete PSKs.
+If a client or server wish to deprecate a hash function and no longer use it for TLS 1.3,
+they may remove the corresponding KDF from the set of target KDFs used for importing keys.
+This does not affect the KDF operation used to derive concrete PSKs.
 
 # Backwards Compatibility and Incremental Deployment
 
@@ -196,17 +209,40 @@ External PSK identities are typically static by design so that endpoints may use
 lookup keying material. However, for some systems and use cases, this identity may become a
 persistent tracking identifier.
 
-# IANA Considerations
+# IANA Considerations {#IANA}
 
-This document makes no IANA requests.
+This specification introduces a new registry for TLS KDF identifiers and defines the following
+KDFID values:
+
++--------------------+-------------+
+| Description        | Value       |
++--------------------+-------------+
+| Reserved           | {0x00,0x00} |
+|                    |             |
+| HKDF_SHA256        | {0x00,0x01} |
+|                    |             |
+| HKDF_SHA384        | {0x00,0x02} |
+|                    |             |
+| TLS12_PRF_MD5      | {0x00,0x03} |
+|                    |             |
+| TLS12_PRF_MD5SHA1  | {0x00,0x04} |
+|                    |             |
+| TLS12_PRF_SHA256   | {0x00,0x05} |
++--------------------+-------------+
+
+New KDFID values are allocated according to the following process:
+
+- Values with the first in the range 0-254 (decimal) are assigned via Specification Required {{!RFC8126}}.
+- Values with the first byte 255 (decimal) are reserved for Private Use {{!RFC8126}}.
 
 --- back
 
 # Acknowledgements
 
-The authors thank Eric Rescorla and Martin Thomson for discussions that led to the production of this document,
-as well as Christian Huitema for input regarding privacy considerations of external PSKs. John Mattsson
-provided input regarding PSK importer deployment considerations.
+The authors thank Eric Rescorla and Martin Thomson for discussions that led to the
+production of this document, as well as Christian Huitema for input regarding privacy
+considerations of external PSKs. John Mattsson provided input regarding PSK importer
+deployment considerations.
 
 # Addressing Selfie
 


### PR DESCRIPTION
Also, remove PSK identity encryption sketch. This was underspecified and
can always be done in a separate draft if desired.

cc @martinthomson