### PR TITLE
Don't use "replace" when describing the binder_key derivation string.

### DIFF
--- a/draft-ietf-tls-external-psk-importer.md
+++ b/draft-ietf-tls-external-psk-importer.md
@@ -226,7 +226,8 @@ key computation is defined as follows:
            V
 ~~~
 
-Imported PSKs replace the string "ext binder" with "imp binder" when deriving `binder_key`.
+Imported PSKs use the string "imp binder" rather than "ext binder" or "res binder"
+when deriving `binder_key`.
 This means the binder key is computed as follows:
 
 ~~~


### PR DESCRIPTION
It's a bit confusing to use the term "replace" when discussing the string
used for derivation. The text only references one of the strings used for
derivation where the diagram references two.